### PR TITLE
Fix layout choice

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -11,7 +11,7 @@ const optionsBuilder = function (argv) {
         name: S(argv.name).slugify().s,
         location: `${S(argv.name).slugify().s}`,
         longname: S(argv.name).humanize().s,
-        layout: `bootstrap`,
+        layout: argv.layout || `bootstrap`,
         author: '',
     };
 };


### PR DESCRIPTION
Give people the option to choose a layout with init command. Use is `git init <name> --layout=<layoutName>`