### PR TITLE
Choose layouts

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -11,7 +11,7 @@ const optionsBuilder = function (argv) {
         name: S(argv.name).slugify().s,
         location: `${S(argv.name).slugify().s}`,
         longname: S(argv.name).humanize().s,
-        layout: `bootstrap`,
+        layout: argv.layout || `bootstrap`,
         author: '',
     };
 };

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -7,6 +7,12 @@ const Project = require('../core/project');
 const version = require('../version');
 
 const optionsBuilder = function (argv) {
+    const layoutsDir = __dirname.split('/').slice(0, 7).concat('layouts').join('/');
+    if (!fs.existsSync(`${layoutsDir}/${argv.layout}`)) {
+        console.log(`${argv.layout} doesn't exist, setting layout to default.`);
+        argv.layout = 'bootstrap';
+    }
+
     return {
         name: S(argv.name).slugify().s,
         location: `${S(argv.name).slugify().s}`,
@@ -21,8 +27,7 @@ const inputNameAndLocation = function (argv, project, options) {
         project.config.name = options.name ||
           prompt(`Enter short name for the blog: `, options.name);
         project.config.location = options.location ||
-          prompt('Enter the folder on which you want to create the site if ' +
-          'different to the name:' + '[' + options.name + '] ', options.location);
+          prompt(`Enter a folder location if different from [${options.name}]:`, options.location);
         project.config.location = options.location ? options.location :
           `${S(options.name).slugify().s}`;
     }

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -27,7 +27,7 @@ const inputNameAndLocation = function (argv, project, options) {
         project.config.name = options.name ||
           prompt(`Enter short name for the blog: `, options.name);
         project.config.location = options.location ||
-          prompt(`Enter a folder location if different from [${options.name}]:`, options.location);
+          prompt(`Enter a folder name if different from [${options.name}]:`, options.location);
         project.config.location = options.location ? options.location :
           `${S(options.name).slugify().s}`;
     }


### PR DESCRIPTION
Enable choosing a layout with `gloria init <name> --layout=<layoutName>.` Checks to make sure the layout exists, if not sets the layout to the 'bootstrap' layout. Also fixed a bug in init with repeating prompt on keypress. Shortening the string appears to have fixed the issue.