### PR TITLE
Add build statistics.

### DIFF
--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -121,18 +121,32 @@ function processFiles(dest, args) {
     project.posts.forEach((post, index) => {
         results.posts.push(Render.post(post, data));
     });
-    for (var result in results) {
+
+    // wrap all the writefiles in promises and then after promise.all call console.timeEnd
+    // and log info
+    const promiseArray = [];
+    for (let result in results) {
         results[result].forEach((page) => {
             let destination = `${dest}${page.destination.folder}${page.destination.file}`;
             fse.ensureDirSync(`${dest}${page.destination.folder}`);
-            fse.writeFile(`${destination}`, page.content, (err) => {
-                if (err) throw err;
+            var writeFile = $q.nfbind(fse.writeFile);
+            promiseArray.push(writeFile(`${destination}`, page.content)
+            .then((result) => {
                 console.log(`file ${destination} written`);
-            });
+            })
+            .catch(error => console.log(error)));
         });
+    };
 
-    }
-
+    $q.all(promiseArray).done(() => {
+        console.timeEnd('Build time');
+        console.log(`# of public files: ${project.public.length}`);
+        console.log(`# of pages: ${project.pages.length}`);
+        console.log(`# of posts: ${project.posts.length}`);
+        console.log(`# of sass: ${project.styles.length}`);
+        console.log(`# of stylus: ${project.stylus.length}`);
+        console.log(`# of JSON: ${project.jsondata.length}`);
+    });
     return;
 }
 
@@ -144,6 +158,9 @@ function handler(argv) {
     const stylusFolder = `${root}${path.sep}_stylus`;
     const postsFolder = `${root}${path.sep}_posts`;
     const dataFolder = `${root}${path.sep}_data`;
+
+    // Build execution timer
+    console.time('Build time');
 
     if (S(argv.dest).include('..')) {
         console.error(`Won't build to a parent directory, mostly security reasons.
@@ -244,6 +261,7 @@ function handler(argv) {
         Render.registerLayouts(project.layouts);
         processFiles(dest, argv);
     });
+
 }
 
 const builder = {


### PR DESCRIPTION
fixes #69 Adds timer to build.handler and logs all build statistics.

![image](https://cloud.githubusercontent.com/assets/5925266/21198774/79cb134e-c1f5-11e6-99a8-9b3734e02b3d.png)

Let me know if there should be other stats, or if I should change how it's written.