### PR TITLE
Remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "tslint": "^4.0.0",
     "typescript": "^2.0.10",
     "typescript-require": "^0.2.9-1",
-    "yaml": "^0.3.0",
     "yamljs": "^0.2.8",
     "yargs": "^6.4.0"
   },


### PR DESCRIPTION
This dependency is not used anywhere. It was originally added to parse
YAML. As an alternative yamljs is used. Since this module does not
support the entire YAML specification.