### PR TITLE
Use frontmatter to customize layouts and includes (Issue #13)

### DIFF
--- a/lib/build/handlebars-helpers.js
+++ b/lib/build/handlebars-helpers.js
@@ -33,8 +33,13 @@ Handlebars.registerPartials = function registerPartials (files) {
             return;
         }
 
+        // calling require here to avoid circular dependencies
+        // http://selfcontained.us/2012/05/08/node-js-circular-dependencies/
+        const Render = require('./render');
+        const fm = Render.extract(file);
         const partial = Object.assign({}, file, {
-            content: fse.readFileSync(file.path, `utf-8`),
+            content: fm.content,
+            variables: fm.fm,
             name: file.name.replace('.html', ''),
         });
         partials[partial.name] = partial;

--- a/lib/build/render.js
+++ b/lib/build/render.js
@@ -20,7 +20,8 @@ const registerLayouts = function (files) {
             return;
         }
 
-        files[k].content = fse.readFileSync(files[k].path, `utf-8`);
+        var layoutFrontMatter = extract(files[k]);
+        Object.assign(files[k], layoutFrontMatter);
         Render.layouts[k] = files[k];
     }
 
@@ -55,10 +56,14 @@ const renderCommon = function (page, content, data) {
         destination.folder = `${folder}`;
         page.name = 'index.html';
     }
-
     data.page.content = result;
     const layoutName = page.data.layout || `default`;
     if (Render.layouts[layoutName]) {
+
+        // g is a namespace for layout and hbs partials' vars
+        data.page.g = {};
+        data.page.g.layout = Render.layouts[layoutName].fm;
+        Object.assign(data.page.g, extractPartialsVariables(Render.layouts[layoutName].content));
         template = Handlebars.compile(Render.layouts[layoutName].content);
         result = template(data);
     }
@@ -129,6 +134,20 @@ const renderPost = function (page, data) {
     result = renderCommon(page, html, data);
     result.destination.folder = path.normalize(`${result.destination.folder}`);
     return result;
+};
+
+const extractPartialsVariables = function (document) {
+    var regex = /{{>([\s\w]+)}}/g;
+    var partialsVars = {};
+    while ((result = regex.exec(document)) !== null) {
+        var partialName = (result[1].trim());
+        var currrentPartial = Render.partials[partialName];
+        if (currrentPartial) {
+            partialsVars[partialName] = currrentPartial.variables;
+        }
+    }
+
+    return partialsVars;
 };
 
 Render['.html'] = renderHtml;


### PR DESCRIPTION
This change allows accessing variables defined in layouts' and includes' frontmatters. This could be achieved through the following syntax. `{{ page.g.layout.var1}}` for accessing layout variables or 
`{{ page.g.head.var1}}` for accessing includes' (hbs partials) variables. `head` here is the name of the include. `g` (short for gloria) acts as a namespace to avoid collision between common variable names like 'title' or 'description'.

